### PR TITLE
https://code.jquery.com/jquery-3.3.1.min.js地址被墙，导致无法正确显示项目。

### DIFF
--- a/dest/js/pixi-examples.min.js
+++ b/dest/js/pixi-examples.min.js
@@ -160,7 +160,7 @@ jQuery(document).ready($ => {
             let html = "<!DOCTYPE html><html><head><style>";
             html += "body,html{margin:0px;height:100%;overflow:hidden;}canvas{width:100%;height:100%;}";
             html += "</style></head><body>";
-            html += '<script src="https://code.jquery.com/jquery-3.3.1.min.js"><\/script>';
+            html += '<script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"><\/script>';
             html += `<script src="${pixiUrl}"><\/script>`;
             for (let i = 0; i < bpc.exampleRequiredPlugins.length; i++) {
                 html += `<script src="pixi-plugins/${bpc.exampleRequiredPlugins[i]}.js"><\/script>`;

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
                 href="https://github.com/zlq4863947/pixi.js-cn.examples" target="_blank">GitHub</a>.</p>
     </article>
 
-    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>
     <script src="vendor/codemirror/codemirror.js"></script>
     <script src="vendor/codemirror/javascript.js"></script>
     <script>

--- a/src/js/pixi-examples.js
+++ b/src/js/pixi-examples.js
@@ -203,7 +203,7 @@ jQuery(document).ready(($) => {
             let html = '<!DOCTYPE html><html><head><style>';
             html += 'body,html{margin:0px;height:100%;overflow:hidden;}canvas{width:100%;height:100%;}';
             html += '</style></head><body>';
-            html += '<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>';
+            html += '<script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>';
             html += `<script src="${pixiUrl}"></script>`;
 
             for (let i = 0; i < bpc.exampleRequiredPlugins.length; i++) {


### PR DESCRIPTION
将https://code.jquery.com/jquery-3.3.1.min.js替换为https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js